### PR TITLE
Fixed Connection retention bug

### DIFF
--- a/SummerSchool/.idea/modules.xml
+++ b/SummerSchool/.idea/modules.xml
@@ -3,8 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/SummerSchool.iml" filepath="$PROJECT_DIR$/SummerSchool.iml" />
-      <module fileurl="file://$PROJECT_DIR$/SummerSchool.iml" filepath="$PROJECT_DIR$/SummerSchool.iml" />
-      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>

--- a/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/ContentsLab.java
+++ b/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/ContentsLab.java
@@ -33,6 +33,7 @@ public class ContentsLab {
     private ArrayList<TimeTable> mTimeTables;
     private ArrayList<TimeTableWeek> mTimeTableWeeks;
     private ArrayList<Lecturer> mLecturers;
+    private ArrayList<String> mLogInData;
 
     public static ContentsLab get() {
         if (sContentsLab == null) {
@@ -41,10 +42,19 @@ public class ContentsLab {
         return sContentsLab;
     }
 
+    public ArrayList<String> getmLogInData() {
+        return mLogInData;
+    }
+
+    public void setmLogInData(ArrayList<String> mLogInData) {
+        this.mLogInData = mLogInData;
+    }
+
     private ContentsLab() {
         mAnnouncements = new ArrayList<>();
         mGeneralInfos = new ArrayList<>();
         mTimeTables = new ArrayList<>();
+
         mTimeTableWeeks = new ArrayList<>();
         mTimeTableWeeks.add(new TimeTableWeek("Monday"));
         mTimeTableWeeks.add(new TimeTableWeek("Tuesday"));

--- a/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/MyProfileFragment.java
+++ b/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/MyProfileFragment.java
@@ -27,7 +27,9 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import nl.rug.www.summerschool.R;
+import nl.rug.www.summerschool.controller.ContentsLab;
 import nl.rug.www.summerschool.controller.myprofile.SignInManager;
+import nl.rug.www.summerschool.model.Content;
 
 /**
  * This class is to show the data fetched from facebook or google+.
@@ -52,27 +54,17 @@ public class MyProfileFragment extends Fragment implements View.OnClickListener{
 
     private static SignInManager SIM;
 
-    //creation of bundle, put arguments in it and set it when creating fragment for return.
-    public static MyProfileFragment newInstance(ArrayList<String> details) {
-        Bundle args = new Bundle();
-        args.putStringArrayList(ARG_CONTENT_ID, details);
-
-        MyProfileFragment fragment = new MyProfileFragment();
-        fragment.setArguments(args);
-        return fragment;
-    }
-
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        //retrieve data from bundle
-        mLogInData = getArguments().getStringArrayList(ARG_CONTENT_ID);
     }
 
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_my_profile, container, false);
+
+        mLogInData = ContentsLab.get().getmLogInData();
 
         String displayName = mLogInData.get(1);
         String email = mLogInData.get(2);

--- a/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/MyProfileFragment.java
+++ b/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/MyProfileFragment.java
@@ -133,11 +133,12 @@ public class MyProfileFragment extends Fragment implements View.OnClickListener{
                 });
     }
 
-    // end of google methods
     @Override
     public void onDestroy() {
         super.onDestroy();
-        SIM.getmGoogleApiClient().stopAutoManage(getActivity());
-        SIM.getmGoogleApiClient().disconnect();
+        if(SIM.getmGoogleApiClient().isConnected()) {
+            SIM.getmGoogleApiClient().stopAutoManage(getActivity());
+            SIM.getmGoogleApiClient().disconnect();
+        }
     }
 }

--- a/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/SignInFragment.java
+++ b/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/SignInFragment.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import nl.rug.www.summerschool.R;
+import nl.rug.www.summerschool.controller.ContentsLab;
 import nl.rug.www.summerschool.controller.myprofile.SignInManager;
 
 /**
@@ -61,7 +62,7 @@ public class SignInFragment extends Fragment implements View.OnClickListener{
     private static final String TAG = "LoginFragment";
 
     private ArrayList<String> mlogInData;
-
+    ContentsLab mContents;
     //FireBase Variables
     private FirebaseAuth mAuth;
     //googlesignin variables
@@ -117,7 +118,13 @@ public class SignInFragment extends Fragment implements View.OnClickListener{
             setMlogInData(currentUser);
         }
     }
-
+    public void onDestroy() {
+        super.onDestroy();
+        if(SIM.getmGoogleApiClient().isConnected()) {
+            SIM.getmGoogleApiClient().stopAutoManage(getActivity());
+            SIM.getmGoogleApiClient().disconnect();
+        }
+    }
     @Override
     public void onClick(View v) {
         switch (v.getId()) {
@@ -143,11 +150,8 @@ public class SignInFragment extends Fragment implements View.OnClickListener{
         mlogInData.add(user.getDisplayName());
         mlogInData.add(user.getEmail());
 
-        for (UserInfo userInfo: FirebaseAuth.getInstance().getCurrentUser().getProviderData()) {
-            if(userInfo.getProviderId().equals("google.com")){
-
-            }
-        }
+        mContents = ContentsLab.get();
+        mContents.setmLogInData(mlogInData);
 
         FragmentManager fm = mActivity.getSupportFragmentManager();
         fm.beginTransaction().replace(R.id.fragment_container, MyProfileFragment.newInstance(mlogInData)).commit();

--- a/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/SignInFragment.java
+++ b/SummerSchool/app/src/main/java/nl/rug/www/summerschool/controller/myprofile/SignInFragment.java
@@ -150,11 +150,10 @@ public class SignInFragment extends Fragment implements View.OnClickListener{
         mlogInData.add(user.getDisplayName());
         mlogInData.add(user.getEmail());
 
-        mContents = ContentsLab.get();
-        mContents.setmLogInData(mlogInData);
+        ContentsLab.get().setmLogInData(mlogInData);
 
         FragmentManager fm = mActivity.getSupportFragmentManager();
-        fm.beginTransaction().replace(R.id.fragment_container, MyProfileFragment.newInstance(mlogInData)).commit();
+        fm.beginTransaction().replace(R.id.fragment_container, new MyProfileFragment()).commit();
     }
     //INIT FIREBASE SERVICE
     private void initFirebaseService(){


### PR DESCRIPTION
- Fixed crash when SigninFragment is visited twice in a row after signing in and out once. (had to set google api to stop automanaging connection ondestroy)
- removed sending of mLogInData through intent bundle. when user is signed in, the user details are now set into ContentsLab and used in MyProfileFragment.

